### PR TITLE
Refactor: bet widget controls

### DIFF
--- a/backend/database/dto/bet.ts
+++ b/backend/database/dto/bet.ts
@@ -1,6 +1,12 @@
 import { Bet } from "shared/models/bet"
 import prisma from "../dbConfig";
 
+interface UserPoints {
+    userId: number;
+    points: number;
+    hasMostPoints: boolean;
+}
+
 export async function createBet(bet: Bet): Promise<Bet> {
     return prisma.bet.create({
         data: bet
@@ -85,4 +91,57 @@ export function getNotEvaluatedBetsInThePast(): Promise<Bet[]> {
             }
         }
     })
+}
+
+export async function getPlayerPointsPerEvent() {
+    const users = await prisma.user.findMany();
+    const events = await prisma.event.findMany();
+
+    const userEventPoints = [];
+
+    for (const event of events) {
+        const betInstances = await prisma.betInstance.findMany({
+            where: {
+                bet: { eventId: event.id },
+                points: {
+                    not: -1 // Ignore instances with points = -1
+                }
+            },
+            include: { user: true },
+        });
+
+        const pointsPerUser: Record<number, UserPoints> = {};
+
+        // Initialize pointsPerUser with 0 points for all users
+        for (const user of users) {
+            pointsPerUser[user.id] = {
+                userId: user.id,
+                points: 0,
+                hasMostPoints: false,
+            };
+        }
+
+        for (const betInstance of betInstances) {
+            const user = betInstance.user;
+            const points = betInstance.points || 0;
+
+            pointsPerUser[user.id].points += points;
+        }
+
+        userEventPoints.push({
+            eventId: event.id,
+            eventName: event.name,
+            pointsPerUser: Object.values(pointsPerUser),
+        });
+    }
+
+    return userEventPoints.map(eventData => {
+        const highestPoints = Math.max(...eventData.pointsPerUser.map(user => user.points));
+
+        eventData.pointsPerUser.forEach(user => {
+            user.hasMostPoints = user.points === highestPoints;
+        });
+
+        return eventData;
+    });
 }

--- a/backend/routes/manageRoute.ts
+++ b/backend/routes/manageRoute.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express'
 import { getBetInstancesByBetId, updateBetInstance } from "../database/dto/betInstance";
 import { calculatePointsForBet } from "../util/points";
-import { getBet, updateBet } from "../database/dto/bet";
+import { getBet, getPlayerPointsPerEvent, updateBet } from "../database/dto/bet";
 import { getBetInstancesPointsPerUserId, getEventsWithMissingBetInstances } from "../database/dto/statistics";
 import { getAllUsers } from "../database/dto/user";
 import { User } from "shared/models/user";
@@ -57,6 +57,21 @@ manageRoute.get('/userpoints', async (req: Request, res: Response): Promise<void
         })
     }
 
+})
+
+manageRoute.get('/userpointsperevent', async (req: Request, res: Response): Promise<void> => {
+    try {
+        const response = await getPlayerPointsPerEvent()
+        res.json({
+            data: response,
+            success: true
+        })
+    } catch (e) {
+        res.json({
+            success: false,
+            message: "ERROR"
+        })
+    }
 })
 
 manageRoute.post('/missingBetEvents', async (req: Request, res: Response): Promise<void> => {

--- a/betterbet/package.json
+++ b/betterbet/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.13.7",
+    "@mui/lab": "^5.0.0-alpha.139",
     "@mui/material": "^5.13.7",
     "@mui/x-date-pickers": "^6.9.2",
     "@testing-library/jest-dom": "^5.16.5",

--- a/betterbet/src/components/BetButtons.tsx
+++ b/betterbet/src/components/BetButtons.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import { Button, Paper } from "@mui/material";
 import React, { useEffect } from "react";
 
 interface BetButtonsProps {
@@ -18,7 +18,7 @@ const BetButtons: React.FC<BetButtonsProps> = ({buttonList, selectedButton, disa
     };
 
     return (
-        <div>
+        <Paper variant="outlined">
             {buttonList.map((e) => (
                 <Button
                     data-key={e}
@@ -30,7 +30,7 @@ const BetButtons: React.FC<BetButtonsProps> = ({buttonList, selectedButton, disa
                     {e}
                 </Button>
             ))}
-        </div>
+        </Paper>
     )
 }
 

--- a/betterbet/src/components/BetWidget.tsx
+++ b/betterbet/src/components/BetWidget.tsx
@@ -111,7 +111,7 @@ const BetWidget: FC<BetWidgetProps> = ({eventId}): ReactElement => {
 
     useEffect(() => {
         if (!isLocked) {
-            if(bet.type === "result") {
+            if (bet.type === "result") {
                 const updateBetInstance = async () => {
                     const response = await api.put('/betInstance', {
                         betId: bet.id,
@@ -385,59 +385,62 @@ const BetWidget: FC<BetWidgetProps> = ({eventId}): ReactElement => {
                             </Grid>
                             <Grid item xs={1}/>
                             <Grid item xs={1} style={{...gridItemStyle, height: 100}}/>
-                            {betType === '1X2' && (
-                                <Grid item xs={10} style={gridItemStyle}>
-                                    <BetButtons buttonList={["1", "X", "2"]} selectedButton={selectedButton}
-                                                disabled={isLocked} onValueChange={handleBetButton}/>
-                                </Grid>
-                            )}
-                            {(betType === 'winner' || betType === '1or2') && (
-                                <Grid item xs={10} style={gridItemStyle}>
-                                    <BetButtons buttonList={["1", "2"]} selectedButton={selectedButton}
-                                                disabled={isLocked} onValueChange={handleBetButton}/>
-                                </Grid>
-                            )}
-                            {betType === 'overunder' && (
-                                <Grid item xs={10} style={gridItemStyle}>
-                                    <BetButtons buttonList={["Über", "Unter"]} selectedButton={selectedButton}
-                                                disabled={isLocked} onValueChange={handleBetButton}/>
-                                </Grid>
-                            )}
-                            {betType === 'question' && (
-                                <Grid item xs={10} style={gridItemStyle}>
-                                    <BetButtons buttonList={["Ja", "Nein"]} selectedButton={selectedButton}
-                                                disabled={isLocked} onValueChange={handleBetButton}/>
-                                </Grid>
-                            )}
-                            {betType === 'result' && (
-                                <Grid item xs={10} style={gridItemStyle}>
-                                    <TextField
-                                        value={homeResult}
-                                        onChange={(e) => setHomeResult(e.target.value)}
-                                        autoFocus
-                                        type="number"
-                                        margin="dense"
-                                        id="textFieldHomeResult"
-                                        label="Heimteam"
-                                        fullWidth
-                                        variant="standard"
-                                        disabled={isLocked === true}
-                                    />
-                                    :
-                                    <TextField
-                                        value={awayResult}
-                                        onChange={(e) => setAwayResult(e.target.value)}
-                                        autoFocus
-                                        type="number"
-                                        margin="dense"
-                                        id="textFieldAwayResult"
-                                        label="Auswärtsteam"
-                                        fullWidth
-                                        variant="standard"
-                                        disabled={isLocked === true}
-                                    />
-                                </Grid>
-                            )}
+                            <Paper variant="outlined">
+                                {betType === '1X2' && (
+                                    <Grid item xs={10} style={gridItemStyle}>
+                                        <BetButtons buttonList={["1", "X", "2"]} selectedButton={selectedButton}
+                                                    disabled={isLocked} onValueChange={handleBetButton}/>
+                                    </Grid>
+                                )}
+                                {(betType === 'winner' || betType === '1or2') && (
+                                    <Grid item xs={10} style={gridItemStyle}>
+                                        <BetButtons buttonList={["1", "2"]} selectedButton={selectedButton}
+                                                    disabled={isLocked} onValueChange={handleBetButton}/>
+                                    </Grid>
+                                )}
+                                {betType === 'overunder' && (
+                                    <Grid item xs={10} style={gridItemStyle}>
+                                        <BetButtons buttonList={["Über", "Unter"]} selectedButton={selectedButton}
+                                                    disabled={isLocked} onValueChange={handleBetButton}/>
+                                    </Grid>
+                                )}
+                                {betType === 'question' && (
+                                    <Grid item xs={10} style={gridItemStyle}>
+                                        <BetButtons buttonList={["Ja", "Nein"]} selectedButton={selectedButton}
+                                                    disabled={isLocked} onValueChange={handleBetButton}/>
+                                    </Grid>
+                                )}
+                                {betType === 'result' && (
+                                    <Grid item xs={10} style={gridItemStyle}>
+                                        <TextField
+                                            value={homeResult}
+                                            onChange={(e) => setHomeResult(e.target.value)}
+                                            autoFocus
+                                            type="number"
+                                            margin="dense"
+                                            id="textFieldHomeResult"
+                                            label="Heimteam"
+                                            fullWidth
+                                            variant="standard"
+                                            disabled={isLocked === true}
+                                        />
+                                        :
+                                        <TextField
+                                            value={awayResult}
+                                            onChange={(e) => setAwayResult(e.target.value)}
+                                            autoFocus
+                                            type="number"
+                                            margin="dense"
+                                            id="textFieldAwayResult"
+                                            label="Auswärtsteam"
+                                            fullWidth
+                                            variant="standard"
+                                            disabled={isLocked === true}
+                                        />
+                                    </Grid>
+
+                                )}
+                            </Paper>
                             <Grid item xs={1}/>
                             <Grid item xs={2}>
                                 <Fab color='primary' aria-label='previous-bet' onClick={handlePreviousBet}>
@@ -643,31 +646,34 @@ const BetWidget: FC<BetWidgetProps> = ({eventId}): ReactElement => {
                             )}
                             {betType === 'result' && (
                                 <Grid item xs={10} style={gridItemStyle}>
-                                    <TextField
-                                        value={homeResult}
-                                        onChange={(e) => setHomeResult(e.target.value)}
-                                        autoFocus
-                                        type="number"
-                                        margin="dense"
-                                        id="textFieldHomeResult"
-                                        label="Heimteam"
-                                        fullWidth
-                                        variant="standard"
-                                        disabled={isLocked === true}
-                                    />
-                                    :
-                                    <TextField
-                                        value={awayResult}
-                                        onChange={(e) => setAwayResult(e.target.value)}
-                                        autoFocus
-                                        type="number"
-                                        margin="dense"
-                                        id="textFieldAwayResult"
-                                        label="Auswärtsteam"
-                                        fullWidth
-                                        variant="standard"
-                                        disabled={isLocked === true}
-                                    />
+                                    <Paper variant="outlined">
+                                        <TextField
+                                            value={homeResult}
+                                            onChange={(e) => setHomeResult(e.target.value)}
+                                            autoFocus
+                                            type="number"
+                                            margin="dense"
+                                            id="textFieldHomeResult"
+                                            label="Heimteam"
+                                            fullWidth
+                                            variant="standard"
+                                            disabled={isLocked === true}
+                                            style={{ maxWidth: '150px' }}
+                                        />
+                                        <TextField
+                                            value={awayResult}
+                                            onChange={(e) => setAwayResult(e.target.value)}
+                                            autoFocus
+                                            type="number"
+                                            margin="dense"
+                                            id="textFieldAwayResult"
+                                            label="Auswärtsteam"
+                                            fullWidth
+                                            variant="standard"
+                                            disabled={isLocked === true}
+                                            style={{ maxWidth: '150px' }}
+                                        />
+                                    </Paper>
                                 </Grid>
                             )}
                             <Grid item xs={1}/>

--- a/betterbet/src/pages/Bets.tsx
+++ b/betterbet/src/pages/Bets.tsx
@@ -18,7 +18,6 @@ const Bets: FC<any> = (): ReactElement => {
     const handleSelectedEventChange = (event: SelectChangeEvent<any>) => {
         const eventId = event.target.value as number;
         setSelectedEvent(eventId);
-        console.log("Set event ID to " + eventId);
     };
 
     useEffect(() => {

--- a/betterbet/src/pages/Register.tsx
+++ b/betterbet/src/pages/Register.tsx
@@ -21,7 +21,6 @@ const RegisterForm: React.FC<RegisterFormProps> = () => {
         try {
             register(username, email, password).then(
                 () => {
-                    console.log("Registered new User!")
                     navigate("/login")
                     window.location.reload()
                 }

--- a/betterbet/src/pages/Statistics.tsx
+++ b/betterbet/src/pages/Statistics.tsx
@@ -149,7 +149,7 @@ const Statistics: FC = (): ReactElement => {
                     {/*event overview*/}
                     <TabPanel value="one">
                         <Grid item xs={12} sm={12}>
-                            <TableContainer component={Paper} style={{maxHeight: 600}}>
+                            <TableContainer component={Paper} style={{maxHeight: 600, minWidth: 1200}}>
                                 <Table stickyHeader>
                                     <TableHead>
                                         <TableRow>
@@ -164,7 +164,14 @@ const Statistics: FC = (): ReactElement => {
                                             <TableRow
                                                 key={e.eventId}
                                             >
-                                                <TableCell>{e.eventName}</TableCell>
+                                                <TableCell
+                                                    align="center"
+                                                    sx={{
+                                                        minWidth: 150,
+                                                    }}
+                                                >
+                                                    {e.eventName}
+                                                </TableCell>
                                                 {e.pointsPerUser && e.pointsPerUser.map((u) => (
                                                     <TableCell
                                                         key={u.userId + "-" + e.eventId}

--- a/betterbet/src/pages/Statistics.tsx
+++ b/betterbet/src/pages/Statistics.tsx
@@ -10,13 +10,16 @@ import {
     Table,
     SelectChangeEvent, TableBody, TableCell, TableContainer,
     TableHead,
-    TableRow, Tooltip
+    TableRow, Tooltip,
+    Tab
 } from "@mui/material";
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
 import { Event } from "shared/models/event";
 import { Bet } from "shared/models/bet";
 import api from "../api";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
-import DeleteIcon from "@mui/icons-material/Delete";
 import { BetInstance } from "shared/models/betInstance";
 
 interface UsernameWithId {
@@ -33,6 +36,11 @@ const Statistics: FC = (): ReactElement => {
     const [userList, setUserList] = React.useState<UsernameWithId[] | undefined>([])
     const [eventIdValue, setEventIdValue] = React.useState<any>(null)
     const [displayedBets, setDisplayedBets] = React.useState<BetWithInstances[] | undefined>(undefined)
+    const [tabValue, setTabValue] = React.useState('one');
+
+    const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
+        setTabValue(newValue);
+    };
 
     const backgroundColor = (points: number | undefined) => {
         if (points === undefined) {
@@ -59,6 +67,7 @@ const Statistics: FC = (): ReactElement => {
                 setEventList(response.data.event);
                 const usersResponse = await api.get("/users")
                 setUserList(usersResponse.data.users)
+                const pointsResponse = await api.get('userpointsperevent')
             } catch (error) {
                 console.error('Error fetching data from API:', error);
             }
@@ -107,70 +116,122 @@ const Statistics: FC = (): ReactElement => {
         }}>
             <Grid container spacing={3} justifyContent="center" alignItems="center"
                   style={{width: '100%', height: '100%'}}>
-                <Grid item xs={12} sm={12}>
-                    <Select
-                        labelId="select-label"
-                        id="eventSelect"
-                        sx={{width: '200px'}}
-                        value={eventIdValue || ''}
-                        onChange={handleSelectEventChange}
-                    >
-                        {eventList && eventList.map((event) => (
-                            <MenuItem key={event.id} value={event.id}>
-                                {event.name}
-                            </MenuItem>
-                        ))}
-                    </Select>
-                </Grid>
-                <Grid item xs={12} sm={12}>
-                    <TableContainer component={Paper} style={{maxHeight: 600}}>
-                        <Table stickyHeader>
-                            <TableHead>
-                                <TableRow>
-                                    <TableCell align="center">Team 1</TableCell>
-                                    <TableCell align="center">Team 2</TableCell>
-                                    <TableCell align="center">Typ</TableCell>
-                                    <TableCell align="center">Kondition</TableCell>
-                                    <TableCell align="center">Frage</TableCell>
-                                    {userList && userList.map((e) => (
-                                        <TableCell align="center">{e.username}</TableCell>
-                                    ))}
-                                </TableRow>
-                            </TableHead>
-                            <TableBody style={{ overflowY: 'auto' }}>
-                                {displayedBets && displayedBets.map((e) => (
-                                    <TableRow
-                                        key={e.id}
-                                    >
-                                        <TableCell align="center">{e.teamHomeDescription}</TableCell>
-                                        <TableCell align="center">{e.teamAwayDescription}</TableCell>
-                                        <TableCell align="center">{e.type}</TableCell>
-                                        <TableCell align="center">{e.typeCondition}</TableCell>
-                                        <TableCell align="center">
-                                            {e.question && (
-                                                <Tooltip title={e.question}>
-                                                    <IconButton>
-                                                        <QuestionMarkIcon/>
-                                                    </IconButton>
-                                                </Tooltip>
-                                            )}
-                                        </TableCell>
-                                        {userList && userList.map((u) => (
-                                            <TableCell
-                                                align="center"
-                                                sx={{backgroundColor: backgroundColor((e.BetInstance.find((b) => b.userId === u.id)?.points))}}
+                <TabContext value={tabValue}>
+                    <Grid item xs={12} sm={12}>
+                        <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
+                            <TabList
+                                value={tabValue}
+                                onChange={handleTabChange}
+                                textColor="secondary"
+                                indicatorColor="secondary"
+                                aria-label="secondary tabs example"
+                            >
+                                <Tab value="one" label="Spieltagsübersicht"/>
+                                <Tab value="two" label="Tippübersicht"/>
+                            </TabList>
+                        </Box>
+                    </Grid>
+                    {/*event overview*/}
+                    <TabPanel value="one">
+                        <Grid item xs={12} sm={12}>
+                            <TableContainer component={Paper} style={{maxHeight: 600}}>
+                                <Table stickyHeader>
+                                    <TableHead>
+                                        <TableRow>
+                                            <TableCell align="center">Spieltag</TableCell>
+                                            {userList && userList.map((e) => (
+                                                <TableCell align="center">{e.username}</TableCell>
+                                            ))}
+                                        </TableRow>
+                                    </TableHead>
+                                    <TableBody style={{overflowY: 'auto'}}>
+                                        {displayedBets && displayedBets.map((e) => (
+                                            <TableRow
+                                                key={e.id}
                                             >
-                                                {(e.BetInstance.find((b) => b.userId === u.id))?.userBet || "---"}
-                                            </TableCell>
+                                                {userList && userList.map((u) => (
+                                                    <TableCell
+                                                        align="center"
+                                                        sx={{backgroundColor: backgroundColor((e.BetInstance.find((b) => b.userId === u.id)?.points))}}
+                                                    >
+                                                        {(e.BetInstance.find((b) => b.userId === u.id))?.userBet || "---"}
+                                                    </TableCell>
+                                                ))}
+                                            </TableRow>
                                         ))}
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                </Grid>
-            </Grid>
+                                    </TableBody>
+                                </Table>
+                            </TableContainer>
+                        </Grid>
+                    </TabPanel>
 
+                    {/*bet overview*/}
+                    <TabPanel value="two">
+                        <Grid item xs={12} sm={12}>
+                            <Select
+                                labelId="select-label"
+                                id="eventSelect"
+                                sx={{width: '200px'}}
+                                value={eventIdValue || ''}
+                                onChange={handleSelectEventChange}
+                            >
+                                {eventList && eventList.map((event) => (
+                                    <MenuItem key={event.id} value={event.id}>
+                                        {event.name}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </Grid>
+                        <Grid item xs={12} sm={12}>
+                            <TableContainer component={Paper} style={{maxHeight: 600}}>
+                                <Table stickyHeader>
+                                    <TableHead>
+                                        <TableRow>
+                                            <TableCell align="center">Team 1</TableCell>
+                                            <TableCell align="center">Team 2</TableCell>
+                                            <TableCell align="center">Typ</TableCell>
+                                            <TableCell align="center">Kondition</TableCell>
+                                            <TableCell align="center">Frage</TableCell>
+                                            {userList && userList.map((e) => (
+                                                <TableCell align="center">{e.username}</TableCell>
+                                            ))}
+                                        </TableRow>
+                                    </TableHead>
+                                    <TableBody style={{overflowY: 'auto'}}>
+                                        {displayedBets && displayedBets.map((e) => (
+                                            <TableRow
+                                                key={e.id}
+                                            >
+                                                <TableCell align="center">{e.teamHomeDescription}</TableCell>
+                                                <TableCell align="center">{e.teamAwayDescription}</TableCell>
+                                                <TableCell align="center">{e.type}</TableCell>
+                                                <TableCell align="center">{e.typeCondition}</TableCell>
+                                                <TableCell align="center">
+                                                    {e.question && (
+                                                        <Tooltip title={e.question}>
+                                                            <IconButton>
+                                                                <QuestionMarkIcon/>
+                                                            </IconButton>
+                                                        </Tooltip>
+                                                    )}
+                                                </TableCell>
+                                                {userList && userList.map((u) => (
+                                                    <TableCell
+                                                        align="center"
+                                                        sx={{backgroundColor: backgroundColor((e.BetInstance.find((b) => b.userId === u.id)?.points))}}
+                                                    >
+                                                        {(e.BetInstance.find((b) => b.userId === u.id))?.userBet || "---"}
+                                                    </TableCell>
+                                                ))}
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </TableContainer>
+                        </Grid>
+                    </TabPanel>
+                </TabContext>
+            </Grid>
         </Box>
     );
 };

--- a/betterbet/src/pages/Statistics.tsx
+++ b/betterbet/src/pages/Statistics.tsx
@@ -31,12 +31,25 @@ interface BetWithInstances extends Bet {
     BetInstance: BetInstance[]
 }
 
+interface PointsPerEvent {
+    eventId: number,
+    eventName: string,
+    pointsPerUser: PointsPerUser[]
+}
+
+interface PointsPerUser {
+    userId: number,
+    points: number,
+    hasMostPoints: boolean
+}
+
 const Statistics: FC = (): ReactElement => {
     const [eventList, setEventList] = React.useState<Event[] | undefined>([])
     const [userList, setUserList] = React.useState<UsernameWithId[] | undefined>([])
     const [eventIdValue, setEventIdValue] = React.useState<any>(null)
     const [displayedBets, setDisplayedBets] = React.useState<BetWithInstances[] | undefined>(undefined)
     const [tabValue, setTabValue] = React.useState('one');
+    const [userPointsPerEvent, setUserPointsPerEvent] = React.useState<PointsPerEvent[]>()
 
     const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
         setTabValue(newValue);
@@ -68,6 +81,8 @@ const Statistics: FC = (): ReactElement => {
                 const usersResponse = await api.get("/users")
                 setUserList(usersResponse.data.users)
                 const pointsResponse = await api.get('userpointsperevent')
+                console.log(pointsResponse.data.data)
+                setUserPointsPerEvent(pointsResponse.data.data)
             } catch (error) {
                 console.error('Error fetching data from API:', error);
             }
@@ -145,16 +160,18 @@ const Statistics: FC = (): ReactElement => {
                                         </TableRow>
                                     </TableHead>
                                     <TableBody style={{overflowY: 'auto'}}>
-                                        {displayedBets && displayedBets.map((e) => (
+                                        {userPointsPerEvent && userPointsPerEvent.map((e) => (
                                             <TableRow
-                                                key={e.id}
+                                                key={e.eventId}
                                             >
-                                                {userList && userList.map((u) => (
+                                                <TableCell>{e.eventName}</TableCell>
+                                                {e.pointsPerUser && e.pointsPerUser.map((u) => (
                                                     <TableCell
+                                                        key={u.userId + "-" + e.eventId}
                                                         align="center"
-                                                        sx={{backgroundColor: backgroundColor((e.BetInstance.find((b) => b.userId === u.id)?.points))}}
+                                                        sx={{ backgroundColor: u.hasMostPoints ? "green" : "white" }}
                                                     >
-                                                        {(e.BetInstance.find((b) => b.userId === u.id))?.userBet || "---"}
+                                                        {u.points}
                                                     </TableCell>
                                                 ))}
                                             </TableRow>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1070,6 +1070,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.13.7",
+        "@mui/lab": "^5.0.0-alpha.139",
         "@mui/material": "^5.13.7",
         "@mui/x-date-pickers": "^6.9.2",
         "@testing-library/jest-dom": "^5.16.5",
@@ -15843,6 +15844,87 @@
         }
       }
     },
+    "node_modules/@mui/lab": {
+      "version": "5.0.0-alpha.139",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.139.tgz",
+      "integrity": "sha512-YlKKELtGZEpd3Hj9cUo6ekwB6RSDzGBw+LlaCBntudhVb4aRn5mQYFej3BYn6fOYz5335jkTgvBt0sEwlSo4qA==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.10",
+        "@mui/system": "^5.14.4",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/@mui/base": {
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
+      "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.6",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.4",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.13.7",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.7.tgz",
@@ -15888,12 +15970,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.7.tgz",
-      "integrity": "sha512-qbSr+udcij5F9dKhGX7fEdx2drXchq7htLNr2Qg2Ma+WJ6q0ERlEqGSBiPiVDJkptcjeVL4DGmcf1wl5+vD4EA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
+      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.7",
+        "@babel/runtime": "^7.22.6",
+        "@mui/utils": "^5.14.4",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -15945,16 +16027,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.7.tgz",
-      "integrity": "sha512-7R2KdI6vr8KtnauEfg9e9xQmPk6Gg/1vGNiALYyhSI+cYztxN6WmlSqGX4bjWn/Sygp1TUE1jhFEgs7MWruhkQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
+      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/private-theming": "^5.13.7",
+        "@babel/runtime": "^7.22.6",
+        "@mui/private-theming": "^5.14.4",
         "@mui/styled-engine": "^5.13.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.7",
-        "clsx": "^1.2.1",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       },
@@ -15983,6 +16065,14 @@
         }
       }
     },
+    "node_modules/@mui/system/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@mui/types": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
@@ -15997,11 +16087,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.7.tgz",
-      "integrity": "sha512-/3BLptG/q0u36eYED7Nhf4fKXmcKb6LjjT7ZMwhZIZSdSxVqDqSTmATW3a56n3KEPQUXCU9TpxAfCBQhs6brVA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
+      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
@@ -19836,6 +19926,43 @@
         "@babel/runtime": "^7.22.5"
       }
     },
+    "@mui/lab": {
+      "version": "5.0.0-alpha.139",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.139.tgz",
+      "integrity": "sha512-YlKKELtGZEpd3Hj9cUo6ekwB6RSDzGBw+LlaCBntudhVb4aRn5mQYFej3BYn6fOYz5335jkTgvBt0sEwlSo4qA==",
+      "requires": {
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.10",
+        "@mui/system": "^5.14.4",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "@mui/base": {
+          "version": "5.0.0-beta.10",
+          "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
+          "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
+          "requires": {
+            "@babel/runtime": "^7.22.6",
+            "@emotion/is-prop-valid": "^1.2.1",
+            "@mui/types": "^7.2.4",
+            "@mui/utils": "^5.14.4",
+            "@popperjs/core": "^2.11.8",
+            "clsx": "^2.0.0",
+            "prop-types": "^15.8.1",
+            "react-is": "^18.2.0"
+          }
+        },
+        "clsx": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+        }
+      }
+    },
     "@mui/material": {
       "version": "5.13.7",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.7.tgz",
@@ -19856,12 +19983,12 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.7.tgz",
-      "integrity": "sha512-qbSr+udcij5F9dKhGX7fEdx2drXchq7htLNr2Qg2Ma+WJ6q0ERlEqGSBiPiVDJkptcjeVL4DGmcf1wl5+vD4EA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
+      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
       "requires": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.7",
+        "@babel/runtime": "^7.22.6",
+        "@mui/utils": "^5.14.4",
         "prop-types": "^15.8.1"
       }
     },
@@ -19877,18 +20004,25 @@
       }
     },
     "@mui/system": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.7.tgz",
-      "integrity": "sha512-7R2KdI6vr8KtnauEfg9e9xQmPk6Gg/1vGNiALYyhSI+cYztxN6WmlSqGX4bjWn/Sygp1TUE1jhFEgs7MWruhkQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
+      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
       "requires": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/private-theming": "^5.13.7",
+        "@babel/runtime": "^7.22.6",
+        "@mui/private-theming": "^5.14.4",
         "@mui/styled-engine": "^5.13.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.7",
-        "clsx": "^1.2.1",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+        }
       }
     },
     "@mui/types": {
@@ -19898,11 +20032,11 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.7.tgz",
-      "integrity": "sha512-/3BLptG/q0u36eYED7Nhf4fKXmcKb6LjjT7ZMwhZIZSdSxVqDqSTmATW3a56n3KEPQUXCU9TpxAfCBQhs6brVA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
+      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
       "requires": {
-        "@babel/runtime": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
@@ -20914,6 +21048,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.13.7",
+        "@mui/lab": "*",
         "@mui/material": "^5.13.7",
         "@mui/x-date-pickers": "^6.9.2",
         "@testing-library/jest-dom": "^5.16.5",
@@ -20928,7 +21063,7 @@
         "dotenv": "^10.0.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
-        "react-country-flag": "*",
+        "react-country-flag": "^3.1.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",


### PR DESCRIPTION
- White background for bet controls for better readability
- statistics page is divided with tabs into two sections:
- - user points per event including highlighting of the event winner
- - user bet overview: see all the bets for every user including highlighting according to the points
- new route to get the points per user per event in a cleaner way